### PR TITLE
feat: improve color contrast in code blocks (CHR-65)

### DIFF
--- a/src/components/TipTap.tsx
+++ b/src/components/TipTap.tsx
@@ -50,7 +50,7 @@ import ts from 'highlight.js/lib/languages/typescript'
 import html from 'highlight.js/lib/languages/xml'
 import hljs from 'highlight.js/lib/core'
 import go from 'highlight.js/lib/languages/go'
-import 'highlight.js/styles/a11y-dark.css'
+import 'highlight.js/styles/github-dark.css'
 
 // load all highlight.js languages
 // import { lowlight } from 'lowlight'


### PR DESCRIPTION
The theme we were using in code blocks has poor contrast in js code blocks. Maybe it was just that `tsx` file extensions but either way, i use that file extension a lot 